### PR TITLE
Fix encoding error in Config#tagged_hash when tagging UTF-8 data

### DIFF
--- a/lib/merkle/config.rb
+++ b/lib/merkle/config.rb
@@ -41,18 +41,20 @@ module Merkle
     # @return [String] Tagged hash value.
     def tagged_hash(data, tag = branch_tag)
       raise ArgumentError, "data must be string." unless data.is_a?(String)
-      data = [data].pack('H*') if hex_string?(data)
+      raise ArgumentError, "tag must be a String." unless tag.is_a?(String)
+
+      data_bin = hex_to_bin(data).b
 
       unless tag.empty?
-        tag_hash = Digest::SHA256.digest(tag)
-        data = tag_hash + tag_hash + data
+        tag_bin = Digest::SHA256.digest(tag).b
+        data_bin = tag_bin + tag_bin + data_bin
       end
 
       case hash_type
       when :sha256
-        Digest::SHA256.digest(data)
+        Digest::SHA256.digest(data_bin)
       when :double_sha256
-        Digest::SHA256.digest(Digest::SHA256.digest(data))
+        Digest::SHA256.digest(Digest::SHA256.digest(data_bin))
       end
     end
   end

--- a/spec/merkle/config_spec.rb
+++ b/spec/merkle/config_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Merkle::Config do
+  describe '#tagged_hash' do
+    context 'with hex input' do
+      let(:config) { described_class.new(hash_type: :sha256, branch_tag: '') }
+
+      it 'unpacks hex and hashes correctly' do
+        hex = '00ff'
+        bin = [hex].pack('H*')
+        raw = config.tagged_hash(hex)
+        expect(raw).to eq(Digest::SHA256.digest(bin))
+      end
+    end
+
+    context 'with UTF-8 input and empty tag' do
+      let(:config) { described_class.new(hash_type: :sha256, branch_tag: '') }
+      let(:utf8) { '元氣が一番' }
+
+      it 'does not raise and returns 32-byte digest' do
+        expect do
+          raw = config.tagged_hash(utf8)
+          expect(raw.bytesize).to eq(32)
+        end.not_to raise_error
+      end
+    end
+
+    context 'with UTF-8 input and non-empty branch_tag' do
+      let(:config) { described_class.new(hash_type: :sha256, branch_tag: 'MyBranch') }
+      let(:utf8) { '元氣が一番' }
+
+      it 'forces binary encoding and hashes without error' do
+        expect do
+          raw = config.tagged_hash(utf8)
+          expect(raw.bytesize).to eq(32)
+          expect(raw.encoding).to eq(Encoding::ASCII_8BIT)
+        end.not_to raise_error
+      end
+    end
+
+    context 'double_sha256 path' do
+      let(:config) { described_class.new(hash_type: :double_sha256, branch_tag: 'T') }
+      let(:data) { 'deadbeef' }
+
+      it 'applies SHA256 twice' do
+        buf = [data].pack('H*')
+        twice = Digest::SHA256.digest(Digest::SHA256.digest(buf))
+        expect(config.tagged_hash(data, '')).to eq(twice)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Background

`Config#tagged_hash` raises an `Encoding::CompatibilityError` if:

* the input `data` is a UTF-8 string (e.g., JSON), and
* a non-empty `branch_tag` or explicit `tag` is supplied.

This occurs because Ruby prohibits concatenation of `ASCII-8BIT` (binary) tag digests with UTF-8-encoded strings.

## Fix

* Convert or unpack the input into a dedicated buffer, and force it to `ASCII-8BIT`.
* Compute the tag digest via `Digest::SHA256.digest(tag)`, and also force it to `ASCII-8BIT`.
* Concatenate `tag_digest + tag_digest + buffer`, then hash as before.
* No behavior change for hex strings or empty tags.

## Notes

* Closes #1